### PR TITLE
[jayden] w02/final

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fe-news",
   "version": "1.0.0",
   "description": "포탈 사이트의 메인 페이지 `뉴스 스탠드`를 구현한 프로젝트",
-  "main": "app.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch:ts": "tsc --watch",

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,10 @@ view(component)를 작게 나누고 최소한의 view에 대해 feature 작성
 
 ### Architecture
 
-- 컴포넌트 별로 MVC 패턴 구현
-  - 이 때, Model과 View의 역할은 각각 상태관리와 화면관리로 명확히 하되, Controller는 Component라고 명명하고 model과 view를 통한 다양한 조작을 맡긴다.
+- 컴포넌트 별로 다른 아키택처 패턴 적용
+  - MVC 아키택처 패턴: Model과 View의 역할은 각각 상태관리와 화면관리로 명확히 하되, Controller는 Component라고 명명하고 model과 view를 통한 다양한 조작을 맡긴다.
+  - Observer 디자인 패턴: MVC로 구현된 컴포넌트에서 Component의 역할을 좀 줄여주는 정도의 로직.
+  - Flux 아키택처 패턴: Observer 디자인 패턴에서 한 단계 더 나아가서 dispatch와 reducer, action을 통해 state를 처리할 예정.
 
 ## Tech Stack
 

--- a/readme.md
+++ b/readme.md
@@ -23,13 +23,14 @@ view(component)를 작게 나누고 최소한의 view에 대해 feature 작성
   - [tailwindCSS](https://tailwindcss.com/)
   - [TypeScript](https://www.typescriptlang.org/)
 
+- Back
+  - [Nodejs](https://nodejs.org/ko)
+  - [Express](https://expressjs.com/ko/)
+
+- DataBase
+  - [MongoDB](https://www.mongodb.com/)
+
 - Bundler(예정)
   - [Vite](https://vitejs-kr.github.io/)
 
-- Back(예정)
-  - [Nodejs](https://nodejs.org/ko)
-  - [Express](https://expressjs.com/ko/)
-  - [Mongoose](https://mongoosejs.com/)
 
-- DataBase(예정)
-  - [MongoDB](https://www.mongodb.com/)

--- a/src/components/footer/FooterComponent.ts
+++ b/src/components/footer/FooterComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { FooterModel } from '@components/footer/FooterModel.js';
 import { FooterView } from '@components/footer/FooterView.js';
 

--- a/src/components/footer/FooterComponent.ts
+++ b/src/components/footer/FooterComponent.ts
@@ -9,9 +9,6 @@ export class FooterComponent implements Component {
   constructor(props?: Props) {
     this._model = new FooterModel();
     this._view = new FooterView();
-
-    const title = 'Footer';
-    this.setState({ title });
   }
 
   get element() {

--- a/src/components/footer/FooterModel.ts
+++ b/src/components/footer/FooterModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class FooterModel extends AbstractModel {
   constructor() {

--- a/src/components/footer/FooterView.ts
+++ b/src/components/footer/FooterView.ts
@@ -7,7 +7,7 @@ export class FooterView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<footer class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center">Footer</footer>`;
+    this._templateElement.innerHTML = `<footer class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 grid place-content-center">Footer</footer>`;
   }
 
   render(state: State) {

--- a/src/components/footer/FooterView.ts
+++ b/src/components/footer/FooterView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class FooterView extends AbstractView {
   constructor() {

--- a/src/components/footer/FooterView.ts
+++ b/src/components/footer/FooterView.ts
@@ -7,13 +7,10 @@ export class FooterView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<footer class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center"></footer>`;
+    this._templateElement.innerHTML = `<footer class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center">Footer</footer>`;
   }
 
   render(state: State) {
-    const { title } = state;
-    if (typeof title === 'string') {
-      this.element.textContent = title;
-    }
+    return;
   }
 }

--- a/src/components/header/HeaderComponent.ts
+++ b/src/components/header/HeaderComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { HeaderModel } from '@components/header/HeaderModel.js';
 import { HeaderView } from '@components/header/HeaderView.js';
 

--- a/src/components/header/HeaderComponent.ts
+++ b/src/components/header/HeaderComponent.ts
@@ -9,9 +9,6 @@ export class HeaderComponent implements Component {
   constructor(props?: Props) {
     this._model = new HeaderModel();
     this._view = new HeaderView();
-
-    const title = 'Header';
-    this.setState({ title });
   }
 
   get element() {

--- a/src/components/header/HeaderModel.ts
+++ b/src/components/header/HeaderModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class HeaderModel extends AbstractModel {
   constructor() {

--- a/src/components/header/HeaderView.ts
+++ b/src/components/header/HeaderView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class HeaderView extends AbstractView {
   constructor() {

--- a/src/components/header/HeaderView.ts
+++ b/src/components/header/HeaderView.ts
@@ -7,13 +7,10 @@ export class HeaderView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<header class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center"></header>`;
+    this._templateElement.innerHTML = `<header class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center">Header</header>`;
   }
 
   render(state: State) {
-    const { title } = state;
-    if (typeof title === 'string') {
-      this.element.textContent = title;
-    }
+    return;
   }
 }

--- a/src/components/header/HeaderView.ts
+++ b/src/components/header/HeaderView.ts
@@ -7,7 +7,7 @@ export class HeaderView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<header class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 text-center">Header</header>`;
+    this._templateElement.innerHTML = `<header class="h-1/6 bg-green-100 border border-green-500 text-3xl text-gray-500 grid place-content-center">Header</header>`;
   }
 
   render(state: State) {

--- a/src/components/main/MainComponent.ts
+++ b/src/components/main/MainComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { MainModel } from '@components/main/MainModel.js';
 import { MainView } from '@components/main/MainView.js';
 import { MainRightComponent } from '@components/main/main__right/MainRightComponent.js';

--- a/src/components/main/MainModel.ts
+++ b/src/components/main/MainModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class MainModel extends AbstractModel {
   constructor() {

--- a/src/components/main/MainView.ts
+++ b/src/components/main/MainView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class MainView extends AbstractView {
   constructor() {

--- a/src/components/main/main__left/MainLeftComponent.ts
+++ b/src/components/main/main__left/MainLeftComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { MainLeftModel } from '@components/main/main__left/MainLeftModel.js';
 import { MainLeftView } from '@components/main/main__left/MainLeftView.js';
 import { NsHeaderComponent } from '@components/main/main__left/ns__header/NsHeaderComponent.js';

--- a/src/components/main/main__left/MainLeftModel.ts
+++ b/src/components/main/main__left/MainLeftModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class MainLeftModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/MainLeftView.ts
+++ b/src/components/main/main__left/MainLeftView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class MainLeftView extends AbstractView {
   constructor() {

--- a/src/components/main/main__left/ns__container/NsContainerComponent.ts
+++ b/src/components/main/main__left/ns__container/NsContainerComponent.ts
@@ -1,4 +1,4 @@
-import { Props, State } from '@custom-types/types';
+import { Props, State, ViewState } from '@custom-types/types';
 import { Component } from '@custom-types/interfaces';
 import { NsContainerModel } from '@components/main/main__left/ns__container/NsContainerModel.js';
 import { NsContainerView } from '@components/main/main__left/ns__container/NsContainerView.js';
@@ -12,14 +12,11 @@ export class NsContainerComponent implements Component {
   constructor(props?: Props) {
     this._model = new NsContainerModel();
     this._view = new NsContainerView();
+    this.attachChildComponents();
 
-    const nsNavbar = new NsNavbarComponent();
-    const nsPressContainer = new NsPressContainerComponent();
-    nsNavbar.attachTo(this);
-    nsPressContainer.attachTo(this);
-
-    const nsCategoryContainer = new NsCategoryContainerObserverViewComponent();
-    nsCategoryContainer.attachTo(this);
+    const view: ViewState = 'GRID';
+    const handleToView = this.handleToView.bind(this);
+    this.setState({ view, handleToView });
   }
 
   get element() {
@@ -37,5 +34,20 @@ export class NsContainerComponent implements Component {
 
   attachTo(component: Component, position: InsertPosition = 'beforeend') {
     component.element.insertAdjacentElement(position, this.element);
+  }
+
+  attachChildComponents(props?: Props) {
+    const nsNavbar = new NsNavbarComponent();
+    const nsPressContainer = new NsPressContainerComponent();
+    const nsCategoryContainer = new NsCategoryContainerObserverViewComponent();
+
+    nsNavbar.attachTo(this);
+    nsPressContainer.attachTo(this);
+    nsCategoryContainer.attachTo(this);
+  }
+
+  handleToView(state: State) {
+    const { view } = state;
+    this.setState({ view });
   }
 }

--- a/src/components/main/main__left/ns__container/NsContainerComponent.ts
+++ b/src/components/main/main__left/ns__container/NsContainerComponent.ts
@@ -4,6 +4,7 @@ import { NsContainerModel } from '@components/main/main__left/ns__container/NsCo
 import { NsContainerView } from '@components/main/main__left/ns__container/NsContainerView.js';
 import { NsNavbarComponent } from '@components/main/main__left/ns__container/ns__navbar/NsNavbarComponent.js';
 import { NsPressContainerComponent } from '@components/main/main__left/ns__container/ns__press-container/NsPressContainerComponent.js';
+import { NsCategoryContainerObserverViewComponent } from '@components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObserverViewComponent.js';
 
 export class NsContainerComponent implements Component {
   private _model: NsContainerModel;
@@ -16,6 +17,9 @@ export class NsContainerComponent implements Component {
     const nsPressContainer = new NsPressContainerComponent();
     nsNavbar.attachTo(this);
     nsPressContainer.attachTo(this);
+
+    const nsCategoryContainer = new NsCategoryContainerObserverViewComponent();
+    nsCategoryContainer.attachTo(this);
   }
 
   get element() {

--- a/src/components/main/main__left/ns__container/NsContainerComponent.ts
+++ b/src/components/main/main__left/ns__container/NsContainerComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsContainerModel } from '@components/main/main__left/ns__container/NsContainerModel.js';
 import { NsContainerView } from '@components/main/main__left/ns__container/NsContainerView.js';
 import { NsNavbarComponent } from '@components/main/main__left/ns__container/ns__navbar/NsNavbarComponent.js';

--- a/src/components/main/main__left/ns__container/NsContainerModel.ts
+++ b/src/components/main/main__left/ns__container/NsContainerModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsContainerModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__container/NsContainerView.ts
+++ b/src/components/main/main__left/ns__container/NsContainerView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class NsContainerView extends AbstractView {
   constructor() {

--- a/src/components/main/main__left/ns__container/NsContainerView.ts
+++ b/src/components/main/main__left/ns__container/NsContainerView.ts
@@ -1,6 +1,6 @@
 import { State } from '@custom-types/types';
 import { AbstractView } from '@custom-types/abstracts.js';
-
+import { $ } from '@utils/dom.js';
 export class NsContainerView extends AbstractView {
   constructor() {
     super();
@@ -11,6 +11,30 @@ export class NsContainerView extends AbstractView {
   }
 
   render(state: State) {
+    this.changeView(state);
+    this.addChangeViewEvent(state);
     return;
+  }
+
+  changeView(state: State) {
+    const { view } = state;
+    if (view === 'GRID') {
+      $('#press-container', this.element)!.classList.remove('hidden');
+      $('#category-container', this.element)!.classList.add('hidden');
+    }
+    if (view === 'LIST') {
+      $('#category-container', this.element)!.classList.remove('hidden');
+      $('#press-container', this.element)!.classList.add('hidden');
+    }
+  }
+
+  addChangeViewEvent(state: State) {
+    const { handleToView } = state;
+    this.setEvent('#list-btn', 'click', (e) => {
+      (handleToView as (state: State) => void)({ view: 'LIST' });
+    });
+    this.setEvent('#grid-btn', 'click', (e) => {
+      (handleToView as (state: State) => void)({ view: 'GRID' });
+    });
   }
 }

--- a/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObserverViewComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObserverViewComponent.ts
@@ -15,7 +15,7 @@ export class NsCategoryContainerObserverViewComponent
 
   // setTemplate은 subscriber 처리하면 안된다. 그러면 element가 초기화되어버림.
   setTemplate() {
-    this._templateElement.innerHTML = `<section class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative"></section>`;
+    this._templateElement.innerHTML = `<section id="category-container" class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative hidden"></section>`;
   }
 
   get state() {

--- a/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObserverViewComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObserverViewComponent.ts
@@ -1,0 +1,42 @@
+import { Component, ObserverViewComponent } from '@custom-types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { AbstractView } from '@src/types/abstracts.js';
+import { NsCategoryContainerObservableModel } from '@components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObsevableModel.js';
+
+export class NsCategoryContainerObserverViewComponent
+  extends AbstractView
+  implements ObserverViewComponent
+{
+  _observerModel: NsCategoryContainerObservableModel;
+  constructor(props?: Props) {
+    super();
+    this._observerModel = new NsCategoryContainerObservableModel();
+  }
+
+  // setTemplate은 subscriber 처리하면 안된다. 그러면 element가 초기화되어버림.
+  setTemplate() {
+    this._templateElement.innerHTML = `<section class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative"></section>`;
+  }
+
+  get state() {
+    return this._observerModel.state;
+  }
+
+  private setState(state: State) {
+    this.subscribe();
+    this._observerModel.setState(state);
+  }
+
+  attachTo(component: Component, position: InsertPosition = 'beforeend') {
+    component.element.insertAdjacentElement(position, this.element);
+  }
+
+  subscribe() {
+    this._observerModel.addSubscriber(this.render.bind(this));
+  }
+
+  // 아래 메서드들은 subscriber이 된다.
+  render(state: State) {
+    return;
+  }
+}

--- a/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObsevableModel.ts
+++ b/src/components/main/main__left/ns__container/ns__category-container/NsCategoryContainerObsevableModel.ts
@@ -1,0 +1,7 @@
+import { AbstractObservableModel } from '@custom-types/abstracts.js';
+
+export class NsCategoryContainerObservableModel extends AbstractObservableModel {
+  constructor() {
+    super();
+  }
+}

--- a/src/components/main/main__left/ns__container/ns__navbar/NsNavbarComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/NsNavbarComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsNavbarModel } from '@components/main/main__left/ns__container/ns__navbar/NsNavbarModel.js';
 import { NsNavbarView } from '@components/main/main__left/ns__container/ns__navbar/NsNavbarView.js';
 import { NavbarLeftComponent } from '@components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftComponent.js';

--- a/src/components/main/main__left/ns__container/ns__navbar/NsNavbarModel.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/NsNavbarModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsNavbarModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__container/ns__navbar/NsNavbarView.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/NsNavbarView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class NsNavbarView extends AbstractView {
   constructor() {

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NavbarLeftModel } from '@components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftModel.js';
 import { NavbarLeftView } from '@components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftView.js';
 

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftModel.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NavbarLeftModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftView.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__left/NavbarLeftView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NavbarLeftView extends AbstractView {

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NavbarRightModel } from '@components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightModel.js';
 import { NavbarRightView } from '@components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightView.js';
 

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightModel.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NavbarRightModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightView.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NavbarRightView extends AbstractView {

--- a/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightView.ts
+++ b/src/components/main/main__left/ns__container/ns__navbar/navbar__right/NavbarRightView.ts
@@ -9,8 +9,8 @@ export class NavbarRightView extends AbstractView {
 
   protected setTemplate() {
     this._templateElement.innerHTML = `<div class="w-1/2 flex flex-row justify-end items-center gap-x-4">
-                                         <img src="/public/images/symbols/list-view.svg" alt="list-view-symbol">
-                                         <img src="/public/images/symbols/grid-view.svg" alt="grid-view-symbol">
+                                         <img id="list-btn" src="/public/images/symbols/list-view.svg" alt="list-view-symbol">
+                                         <img id="grid-btn" src="/public/images/symbols/grid-view.svg" alt="grid-view-symbol">
                                        </div>`;
   }
 

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerComponent.ts
@@ -5,9 +5,12 @@ import { NsPressContainerView } from '@components/main/main__left/ns__container/
 import { customGet } from '@utils/customFetch.js';
 import {
   BASIC_URL,
-  PRESS_GRID_CONTAINER_COUNT,
-  PRESS_GRID_ITEM_COUNT,
+  PRESS_CONTAINER_PAGE_END,
+  PRESS_CONTAINER_ITEM_COUNT,
+  PRESS_CONTAINER_PAGE_UNIT,
+  PRESS_CONTAINER_PAGE_START,
 } from '@src/constants/constants.js';
+
 import { pickRandomData } from '@utils/pickRandomData.js';
 
 export class NsPressContainerComponent implements Component {
@@ -19,7 +22,7 @@ export class NsPressContainerComponent implements Component {
 
     this.setInitState({
       articlesPromise: this.getRandomArticles(),
-      page: 0,
+      page: PRESS_CONTAINER_PAGE_START,
       handleToPrev: this.handleToPrev.bind(this),
       handleToNext: this.handleToNext.bind(this),
     });
@@ -51,7 +54,8 @@ export class NsPressContainerComponent implements Component {
 
   async getRandomArticles() {
     const articleData = await this.getArticles();
-    const totalItemCount = PRESS_GRID_CONTAINER_COUNT * PRESS_GRID_ITEM_COUNT;
+    const totalItemCount =
+      PRESS_CONTAINER_PAGE_END * PRESS_CONTAINER_ITEM_COUNT;
     return pickRandomData(articleData, totalItemCount);
   }
 
@@ -71,16 +75,19 @@ export class NsPressContainerComponent implements Component {
   }
 
   handleToPrev() {
-    const page = +this.state.page - 1 < 0 ? 0 : +this.state.page - 1;
+    const page =
+      +this.state.page - PRESS_CONTAINER_PAGE_UNIT < PRESS_CONTAINER_PAGE_START
+        ? PRESS_CONTAINER_PAGE_START
+        : +this.state.page - PRESS_CONTAINER_PAGE_UNIT;
     this.setState({ page });
   }
 
   handleToNext() {
     const page =
-      +this.state.page + 1 > PRESS_GRID_CONTAINER_COUNT
-        ? PRESS_GRID_CONTAINER_COUNT
-        : +this.state.page + 1;
-    if (page === PRESS_GRID_CONTAINER_COUNT) return;
+      +this.state.page + PRESS_CONTAINER_PAGE_UNIT > PRESS_CONTAINER_PAGE_END
+        ? PRESS_CONTAINER_PAGE_END
+        : +this.state.page + PRESS_CONTAINER_PAGE_UNIT;
+    if (page === PRESS_CONTAINER_PAGE_END) return;
     this.setState({ page });
   }
 }

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerComponent.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerComponent.ts
@@ -1,5 +1,5 @@
-import { Article, Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Article, Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsPressContainerModel } from '@components/main/main__left/ns__container/ns__press-container/NsPressContainerModel.js';
 import { NsPressContainerView } from '@components/main/main__left/ns__container/ns__press-container/NsPressContainerView.js';
 import { customGet } from '@utils/customFetch.js';

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerModel.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsPressContainerModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
@@ -2,8 +2,9 @@ import { Article, State } from '@src/types/types';
 import { AbstractView } from '@src/types/abstracts.js';
 import { $ } from '@utils/dom.js';
 import {
-  PRESS_GRID_CONTAINER_COUNT,
-  PRESS_GRID_ITEM_COUNT,
+  PRESS_CONTAINER_PAGE_END,
+  PRESS_CONTAINER_ITEM_COUNT,
+  PRESS_CONTAINER_PAGE_START,
 } from '@src/constants/constants.js';
 
 export class NsPressContainerView extends AbstractView {
@@ -27,7 +28,7 @@ export class NsPressContainerView extends AbstractView {
   render(state: State) {
     this.addGridItems(state);
     this.addGridButtonEvent(state);
-    this.toggleButton(state);
+    this.toggleGridButton(state);
   }
 
   addGridItems(state: State) {
@@ -38,8 +39,8 @@ export class NsPressContainerView extends AbstractView {
     ($('#ns__grid-container', this.element) as HTMLUListElement).innerHTML =
       imgSources
         .slice(
-          +page * PRESS_GRID_ITEM_COUNT,
-          (+page + 1) * PRESS_GRID_ITEM_COUNT,
+          +page * PRESS_CONTAINER_ITEM_COUNT,
+          (+page + 1) * PRESS_CONTAINER_ITEM_COUNT,
         )
         .reduce((acc, cur) => {
           return (
@@ -55,7 +56,8 @@ export class NsPressContainerView extends AbstractView {
     this.setEvent('#btn-next', 'click', handleToNext as EventListener);
   }
 
-  toggleButton(state: State) {
+  toggleGridButton(state: State) {
+    // 추후 코드 리팩토링
     const { page } = state;
     ($('#btn-prev', this.element) as HTMLButtonElement).classList.remove(
       'invisible',
@@ -63,12 +65,12 @@ export class NsPressContainerView extends AbstractView {
     ($('#btn-next', this.element) as HTMLButtonElement).classList.remove(
       'invisible',
     );
-    if (page === 0) {
+    if (page === PRESS_CONTAINER_PAGE_START) {
       ($('#btn-prev', this.element) as HTMLButtonElement).classList.add(
         'invisible',
       );
     }
-    if (page === PRESS_GRID_CONTAINER_COUNT - 1) {
+    if (page === PRESS_CONTAINER_PAGE_END - 1) {
       ($('#btn-next', this.element) as HTMLButtonElement).classList.add(
         'invisible',
       );

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
@@ -13,11 +13,11 @@ export class NsPressContainerView extends AbstractView {
   }
 
   setTemplate() {
-    this._templateElement.innerHTML = `<section class="px-3 flex-auto flex flex-row justify-between items-center relative">
+    this._templateElement.innerHTML = `<section class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative">
                                          <button id="btn-prev" class="absolute left-0 border rounded-full bg-white drop-shadow-very-xl">
                                            <img src="/public/images/symbols/chevron-left.svg" alt="chevron-left" class="h-6 w-6"/>
                                          </button>
-                                         <ul id="ns__grid-container" class="grid grid-cols-6 grid-rows-4 w-full h-full">
+                                         <ul id="ns__grid-container" class="grid grid-cols-6 grid-rows-4 w-full h-full gap-px bg-gray-200 border border-gray-200">
                                          </ul>                                      
                                          <button id="btn-next" class="absolute right-0 border rounded-full bg-white drop-shadow-very-xl">
                                            <img src="/public/images/symbols/chevron-right.svg" alt="chevron-right" class="h-6 w-6"/>
@@ -45,7 +45,7 @@ export class NsPressContainerView extends AbstractView {
         .reduce((acc, cur) => {
           return (
             acc +
-            `<li class="border border-gray-100 grid place-content-center"><img class="h-5" src="${cur}" alt="${cur}"></li>`
+            `<li class="grid place-content-center bg-white"><img class="h-5" src="${cur}" alt="${cur}"></li>`
           );
         }, '');
   }

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
@@ -1,5 +1,5 @@
-import { Article, State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { Article, State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 import {
   PRESS_CONTAINER_PAGE_END,

--- a/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
+++ b/src/components/main/main__left/ns__container/ns__press-container/NsPressContainerView.ts
@@ -13,7 +13,7 @@ export class NsPressContainerView extends AbstractView {
   }
 
   setTemplate() {
-    this._templateElement.innerHTML = `<section class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative">
+    this._templateElement.innerHTML = `<section id="press-container" class="px-3 py-3 flex-auto flex flex-row justify-between items-center relative">
                                          <button id="btn-prev" class="absolute left-0 border rounded-full bg-white drop-shadow-very-xl">
                                            <img src="/public/images/symbols/chevron-left.svg" alt="chevron-left" class="h-6 w-6"/>
                                          </button>

--- a/src/components/main/main__left/ns__header/NsHeaderComponent.ts
+++ b/src/components/main/main__left/ns__header/NsHeaderComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsHeaderModel } from '@components/main/main__left/ns__header/NsHeaderModel.js';
 import { NsHeaderView } from '@components/main/main__left/ns__header/NsHeaderView.js';
 import { NsTitleComponent } from '@components/main/main__left/ns__header/ns__title/NsTitleComponent.js';

--- a/src/components/main/main__left/ns__header/NsHeaderModel.ts
+++ b/src/components/main/main__left/ns__header/NsHeaderModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsHeaderModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__header/NsHeaderView.ts
+++ b/src/components/main/main__left/ns__header/NsHeaderView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class NsHeaderView extends AbstractView {
   constructor() {

--- a/src/components/main/main__left/ns__header/ns__date/NsDateComponent.ts
+++ b/src/components/main/main__left/ns__header/ns__date/NsDateComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsDateModel } from '@components/main/main__left/ns__header/ns__date/NsDateModel.js';
 import { NsDateView } from '@components/main/main__left/ns__header/ns__date/NsDateView.js';
 import { getKrDate } from '@utils/date.js';

--- a/src/components/main/main__left/ns__header/ns__date/NsDateModel.ts
+++ b/src/components/main/main__left/ns__header/ns__date/NsDateModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsDateModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__header/ns__date/NsDateView.ts
+++ b/src/components/main/main__left/ns__header/ns__date/NsDateView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NsDateView extends AbstractView {

--- a/src/components/main/main__left/ns__header/ns__title/NsTitleComponent.ts
+++ b/src/components/main/main__left/ns__header/ns__title/NsTitleComponent.ts
@@ -9,9 +9,6 @@ export class NsTitleComponent implements Component {
   constructor(props?: Props) {
     this._model = new NsTitleModel();
     this._view = new NsTitleView();
-
-    const title = '뉴스스탠드';
-    this.setState({ title });
   }
 
   get element() {

--- a/src/components/main/main__left/ns__header/ns__title/NsTitleComponent.ts
+++ b/src/components/main/main__left/ns__header/ns__title/NsTitleComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsTitleModel } from '@components/main/main__left/ns__header/ns__title/NsTitleModel.js';
 import { NsTitleView } from '@components/main/main__left/ns__header/ns__title/NsTitleView.js';
 

--- a/src/components/main/main__left/ns__header/ns__title/NsTitleModel.ts
+++ b/src/components/main/main__left/ns__header/ns__title/NsTitleModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsTitleModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__header/ns__title/NsTitleView.ts
+++ b/src/components/main/main__left/ns__header/ns__title/NsTitleView.ts
@@ -10,14 +10,11 @@ export class NsTitleView extends AbstractView {
   protected setTemplate() {
     this._templateElement.innerHTML = `<div class="w-1/2 h-full flex flex-row justify-start items-center gap-x-2">
                                          <img src="/public/images/symbols/newspaper.svg" alt="newspaper-symbol">
-                                         <p class="text-2xl font-bold"></p>
+                                         <p class="text-2xl font-bold">뉴스스탠드</p>
                                        </div>`;
   }
 
   render(state: State) {
-    const { title } = state;
-    if (typeof title === 'string') {
-      ($('p', this.element) as HTMLParagraphElement).innerText = title;
-    }
+    return;
   }
 }

--- a/src/components/main/main__left/ns__header/ns__title/NsTitleView.ts
+++ b/src/components/main/main__left/ns__header/ns__title/NsTitleView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NsTitleView extends AbstractView {
@@ -8,10 +8,10 @@ export class NsTitleView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<div class="w-1/2 h-full flex flex-row justify-start items-center gap-x-2">
+    this._templateElement.innerHTML = `<a href="" class="w-1/2 h-full flex flex-row justify-start items-center gap-x-2">
                                          <img src="/public/images/symbols/newspaper.svg" alt="newspaper-symbol">
                                          <p class="text-2xl font-bold">뉴스스탠드</p>
-                                       </div>`;
+                                       </a>`;
   }
 
   render(state: State) {

--- a/src/components/main/main__left/ns__issue-container/NsIssueContainerComponent.ts
+++ b/src/components/main/main__left/ns__issue-container/NsIssueContainerComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsIssueContainerModel } from '@components/main/main__left/ns__issue-container/NsIssueContainerModel.js';
 import { NsIssueContainerView } from '@components/main/main__left/ns__issue-container/NsIssueContainerView.js';
 import { NsIssueComponent } from '@components/main/main__left/ns__issue-container/ns__issue/NsIssueComponent.js';

--- a/src/components/main/main__left/ns__issue-container/NsIssueContainerModel.ts
+++ b/src/components/main/main__left/ns__issue-container/NsIssueContainerModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsIssueContainerModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__issue-container/NsIssueContainerView.ts
+++ b/src/components/main/main__left/ns__issue-container/NsIssueContainerView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NsIssueContainerView extends AbstractView {

--- a/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueComponent.ts
+++ b/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { NsIssueModel } from '@components/main/main__left/ns__issue-container/ns__issue/NsIssueModel.js';
 import { NsIssueView } from '@components/main/main__left/ns__issue-container/ns__issue/NsIssueView.js';
 

--- a/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueModel.ts
+++ b/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class NsIssueModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueView.ts
+++ b/src/components/main/main__left/ns__issue-container/ns__issue/NsIssueView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 import { $ } from '@utils/dom.js';
 
 export class NsIssueView extends AbstractView {

--- a/src/components/main/main__right/MainRightComponent.ts
+++ b/src/components/main/main__right/MainRightComponent.ts
@@ -9,9 +9,6 @@ export class MainRightComponent implements Component {
   constructor(props?: Props) {
     this._model = new MainRightModel();
     this._view = new MainRightView();
-
-    const title = 'MainRight';
-    this.setState({ title });
   }
 
   get element() {

--- a/src/components/main/main__right/MainRightComponent.ts
+++ b/src/components/main/main__right/MainRightComponent.ts
@@ -1,5 +1,5 @@
-import { Props, State } from '@src/types/types';
-import { Component } from '@src/types/interfaces';
+import { Props, State } from '@custom-types/types';
+import { Component } from '@custom-types/interfaces';
 import { MainRightModel } from '@components/main/main__right/MainRightModel.js';
 import { MainRightView } from '@components/main/main__right/MainRightView.js';
 

--- a/src/components/main/main__right/MainRightModel.ts
+++ b/src/components/main/main__right/MainRightModel.ts
@@ -1,4 +1,4 @@
-import { AbstractModel } from '@src/types/abstracts.js';
+import { AbstractModel } from '@custom-types/abstracts.js';
 
 export class MainRightModel extends AbstractModel {
   constructor() {

--- a/src/components/main/main__right/MainRightView.ts
+++ b/src/components/main/main__right/MainRightView.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { AbstractView } from '@src/types/abstracts.js';
+import { State } from '@custom-types/types';
+import { AbstractView } from '@custom-types/abstracts.js';
 
 export class MainRightView extends AbstractView {
   constructor() {

--- a/src/components/main/main__right/MainRightView.ts
+++ b/src/components/main/main__right/MainRightView.ts
@@ -7,13 +7,10 @@ export class MainRightView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<section class="h-full w-1/3 bg-green-100 border border-green-500 flex-initial text-3xl text-gray-500 text-center"></section>`;
+    this._templateElement.innerHTML = `<section class="h-full w-1/3 bg-green-100 border border-green-500 flex-initial text-3xl text-gray-500 text-center">MainRight</section>`;
   }
 
   render(state: State) {
-    const { title } = state;
-    if (typeof title === 'string') {
-      this.element.textContent = title;
-    }
+    return;
   }
 }

--- a/src/components/main/main__right/MainRightView.ts
+++ b/src/components/main/main__right/MainRightView.ts
@@ -7,7 +7,7 @@ export class MainRightView extends AbstractView {
   }
 
   protected setTemplate() {
-    this._templateElement.innerHTML = `<section class="h-full w-1/3 bg-green-100 border border-green-500 flex-initial text-3xl text-gray-500 text-center">MainRight</section>`;
+    this._templateElement.innerHTML = `<section class="h-full w-1/3 bg-green-100 border border-green-500 flex-initial text-3xl text-gray-500 grid place-content-center">MainRight</section>`;
   }
 
   render(state: State) {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,6 @@
 export const KR_DAYS = ['일', '월', '화', '수', '목', '금', '토'];
 export const BASIC_URL = 'http://localhost:1116';
-export const PRESS_GRID_CONTAINER_COUNT = 4;
-export const PRESS_GRID_ITEM_COUNT = 24;
+export const PRESS_CONTAINER_ITEM_COUNT = 24;
+export const PRESS_CONTAINER_PAGE_START = 0;
+export const PRESS_CONTAINER_PAGE_END = 4;
+export const PRESS_CONTAINER_PAGE_UNIT = 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ import { $ } from '@utils/dom.js';
 import { App } from '@components/app.js';
 
 const rootElement = $('#root') as HTMLElement;
-const app = new App(rootElement);
+new App(rootElement);

--- a/src/types/abstracts.ts
+++ b/src/types/abstracts.ts
@@ -1,5 +1,5 @@
-import { ObserverSubscriber, State, Props } from '@src/types/types';
-import { Model, ObservableModel, View } from '@src/types/interfaces';
+import { ObserverSubscriber, State } from '@custom-types/types';
+import { Model, ObservableModel, View } from '@custom-types/interfaces';
 import { $ } from '@utils/dom.js';
 
 export abstract class AbstractModel implements Model {

--- a/src/types/abstracts.ts
+++ b/src/types/abstracts.ts
@@ -66,6 +66,7 @@ export abstract class AbstractObservableModel implements ObservableModel {
 
   setState(newState: State) {
     this._state = { ...this._state, ...newState };
+    this.notify(this._state);
   }
 
   get state() {

--- a/src/types/abstracts.ts
+++ b/src/types/abstracts.ts
@@ -1,5 +1,5 @@
-import { State } from '@src/types/types';
-import { Component, Model, View } from '@src/types/interfaces';
+import { ObserverSubscriber, State, Props } from '@src/types/types';
+import { Model, ObservableModel, View } from '@src/types/interfaces';
 import { $ } from '@utils/dom.js';
 
 export abstract class AbstractModel implements Model {
@@ -16,6 +16,7 @@ export abstract class AbstractModel implements Model {
     return this._state;
   }
 }
+
 export abstract class AbstractView implements View {
   protected _templateElement: HTMLTemplateElement;
   protected _element: HTMLElement;
@@ -51,5 +52,35 @@ export abstract class AbstractView implements View {
     handler: EventListener,
   ) {
     $(selector, this.element)!.addEventListener(eventName, handler);
+  }
+}
+
+export abstract class AbstractObservableModel implements ObservableModel {
+  _subscribers: Set<ObserverSubscriber>;
+  private _state: State;
+
+  protected constructor() {
+    this._state = {};
+    this._subscribers = new Set();
+  }
+
+  setState(newState: State) {
+    this._state = { ...this._state, ...newState };
+  }
+
+  get state() {
+    return this._state;
+  }
+
+  addSubscriber(subscriber: ObserverSubscriber) {
+    this._subscribers.add(subscriber);
+  }
+
+  deleteSubscriber(subscriber: ObserverSubscriber) {
+    this._subscribers.delete(subscriber);
+  }
+
+  notify(state: State) {
+    this._subscribers.forEach((subscriber) => subscriber(state));
   }
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,5 +1,8 @@
 import { State } from './types';
 
+/**
+ * MVC
+ */
 export interface Model {
   setState(state: State): void;
   get state(): State;
@@ -20,3 +23,26 @@ export interface Component {
   attachTo(component: Component): void;
   get state(): State;
 }
+
+/**
+ * Observer Pattern
+ */
+export interface ObservableModel extends Model {
+  _subscribers: Set<(state: State) => void>;
+  addSubscriber(subscriber: (state: State) => void): void;
+  deleteSubscriber(subscriber: (state: State) => void): void;
+  notify(state: State): void;
+}
+
+// 마찬가지로 View와 Component 역할을 하는 ObserverViewComponent는 interface로만 관리
+export interface ObserverViewComponent extends View, Component {}
+
+/**
+ * Flux
+ */
+// export interface Store extends Observable {
+//   // private _state: State;
+//   get state(): State;
+//   // action type은 추후에 정의해보기
+//   dispatch(action: string): void;
+// }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -35,7 +35,9 @@ export interface ObservableModel extends Model {
 }
 
 // 마찬가지로 View와 Component 역할을 하는 ObserverViewComponent는 interface로만 관리
-export interface ObserverViewComponent extends View, Component {}
+export interface ObserverViewComponent extends View, Component {
+  subscribe(): void;
+}
 
 /**
  * Flux

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,3 +1,4 @@
+// state
 export type Props = Record<
   string,
   string | number | boolean | object | EventListener
@@ -6,6 +7,11 @@ export type State = Record<
   string,
   string | number | boolean | object | EventListener
 >;
+
+// observer
+export type ObserverSubscriber = (state: State) => void;
+
+// fetching-data
 export type Issue = {
   leftRollingData: string[];
   rightRollingData: string[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -33,3 +33,6 @@ export type Article = {
     noticeMessage: string;
   };
 };
+
+// ns__conatiner
+export type ViewState = 'GRID' | 'LIST';

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,9 +1,9 @@
 export const $ = (
   selector: string,
-  parent: Document | HTMLElement = document,
-) => parent.querySelector(selector);
+  baseElement: Document | HTMLElement = document,
+) => baseElement.querySelector(selector);
 
 export const $$ = (
   selector: string,
-  parent: Document | HTMLElement = document,
-) => parent.querySelectorAll(selector);
+  baseElement: Document | HTMLElement = document,
+) => baseElement.querySelectorAll(selector);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,9 @@ module.exports = {
           '0 45px 65px rgba(0, 0, 0, 0.15)',
         ],
       },
+      gap: {
+        half: '0.5px',
+      },
     },
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
        "@components/*": ["src/components/*"],
        "@styles/*": ["src/styles/*"],
        "@utils/*": ["src/utils/*"],
-       "@types/*": ["src/types/*"],
+       "@custom-types/*": ["src/types/*"],
      },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
# Week 02

**23.04.10(월) ~ 23.04.14(금)**

## Final

## 4.13(목)

## 계획

- Observer Pattern
  - [x] 개념 공부하기
  - [ ] 작게 컴포넌트 하나 만들어보기
- Flux Architecture
  - [x] 개념 공부하기

## 고민 사항

### 1. Observer Pattern과 Flux Architecture

이 둘 중 어떤 걸 이용해서 component를 구현할지 고민이 된다. 일단 MVC에서 좀더 쉽게 변화를 주기 위해서는 MV만을 두고 이 둘을 Observer pattern으로 묶는 게 더 쉬울 것 같다. 먼저 Observer Pattern으로 컴포넌트를 구현하고 추후에 reducer와 dispatcher, action을 개념을 섞어서 Flux Architecture로 구현해보자!

## 4.14(금)

- [x] 옵저버 패턴 컴포넌트 구현
  - 일단 ns__category-container를 옵저버 패턴으로 구현해보기
- [ ] Flux 아키텍처 패턴 컴포넌트 구현
  - store를 전역 상태 관리로 할지, 컴포넌트 별 store를 둘지 잘 설계해서 접근하기
 
## 고민 사항

### 1. 기존 MVC 패턴 컴포넌트와 Observer 패턴 컴포넌트의 조화

단순하게 생각하면 둘 다 element 형식의 객체만 반환할 수 있다면 그 안에서 template을 만들든, 이벤트를 붙이든 등등 여러 작업을은 역할과 책임 부여만 잘해주면 다 될 것 같다. 문제는 하나의 부모 컴포넌트에서 다른 패턴으로 구현된 컴포넌트를 관리할 때일 것 같다. 데이터 전달 로직이 다르니까 조금 복잡해질 것 같다. 일단 배우는 단계니까 적용해보자. 아마도 MVC와 Obsever 패턴 간의 충돌은 크게 없을 것 같다.

### 2. tsconfig path 설정 오류

import 해오는 파일들의 상대경로가 너무 길어져서 tsconfig path 설정을 해주었다.
```json
"paths": {
       "@src/*": ["src/*"],
       "@components/*": ["src/components/*"],
       "@styles/*": ["src/styles/*"],
       "@utils/*": ["src/utils/*"],
       "@types/*": ["src/types/*"],
     },      
```

헌데 이상하게, @types만 계속 에러가 발생한다. 

<img width="689" alt="스크린샷 2023-04-14 09 57 18" src="https://user-images.githubusercontent.com/86241737/231914108-ab761683-ef83-40aa-a864-b0e4b71788b5.png">

처음엔 이유를 모르겠다가, 가만 보니까 `@types` 이름이 문제였다... 이렇게 지으면 다른 라이브러리의 타입을 가져오듯이 처리가 되어서 declare 파일을 찾게 되는 것이었다!!!! ex) `@types/node`
이름을 `@custom-types`으로 수정해서 해결!!!

### 3. 같은 계층의 컴포넌트끼리 서로의 상태를 변경하는 방법

같은 계층의 컴포넌트 A와 B가 있을 때, A의 View를 클릭하면 B의 상태가 변경되는 방법이 쉽지가 않다. 결국엔 서로의 공통 분모인 부모 컴포넌트를 통해야지만 가능할 것 같은데... 이 부분이 해결되어야 grid에서 list view로 전환되는 것을 구현할 수 있다. 좀더 고민하고 다양하게 시도해보자..!
=> 리액트의 예시를 찾아보니 depth가 1 정도면 그 위의 부모 컴포넌트에서 관리하면 되지만 그게 아니라면 웬만하면 리덕스같은 라이브러리로 처리해주는 게 좋다고 한다.