### PR TITLE
[사랑대디] 뉴스스탠드 4주차 PR

### DIFF
--- a/css/news-stand/components/news-journal/journal-detail.css
+++ b/css/news-stand/components/news-journal/journal-detail.css
@@ -97,3 +97,7 @@
 .navType span:first-child:hover {
   text-decoration: underline;
 }
+
+.sub-button {
+  cursor: pointer;
+}

--- a/css/news-stand/components/news-journal/journal-detail.css
+++ b/css/news-stand/components/news-journal/journal-detail.css
@@ -98,6 +98,16 @@
   text-decoration: underline;
 }
 
-.sub-button {
+.sub-button button {
   cursor: pointer;
+  color: var(--gray300);
+  border-radius: 10px;
+  border: none;
+  padding: 5px;
+  background-color: #f2f2f2;
+  transition: background-color 0.2s ease;
+}
+
+.sub-button button:active {
+  background-color: #d9d9d9;
 }

--- a/src/components/journalList/journal.js
+++ b/src/components/journalList/journal.js
@@ -1,49 +1,49 @@
 export class Journal {
   constructor(journalData, journalHeaderStore, journalDetailStore) {
+    this.journalData = journalData;
     this.journalHeaderStore = journalHeaderStore;
     this.journalDetailStore = journalDetailStore;
-    this.journalData = journalData;
     this.gridElement = document.createElement("div");
     this.gridElement.classList.add("journal-item");
     this.detailElement = document.createElement("div");
     this.detailElement.classList.add("journal-detail");
-    this.renderGrid();
-    this.renderDetail();
+    this.renderToGridArticle();
+    this.renderToDetailArticle();
   }
 
-  getGridHTML() {
+  getGridArticleHTML() {
     const btnLabels = [
       ["구독", "subscribe-btn"],
       ["해지", "unsubscribe-btn"],
     ];
-    const journalCell = document.createElement("div");
-    journalCell.classList.add("journal-item_show");
-    this.gridElement.appendChild(journalCell);
-    journalCell.innerHTML = `<img src="${this.journalData.mediaInfo.imgSrc}" 
+    const displayJournalCell = document.createElement("div");
+    displayJournalCell.classList.add("journal-item_show");
+    this.gridElement.appendChild(displayJournalCell);
+    displayJournalCell.innerHTML = `<img src="${this.journalData.mediaInfo.imgSrc}" 
                          alt="${this.journalData.mediaInfo.name}">`;
-    journalCell.style.display = "flex";
+    displayJournalCell.style.display = "flex";
 
-    const subCell = document.createElement("div");
-    subCell.classList.add("journal-item_hover");
+    const displaySubCell = document.createElement("div");
+    displaySubCell.classList.add("journal-item_hover");
 
-    const btns = [];
+    const subOrNotBtns = [];
     btnLabels.forEach((btnLabel) => {
       const btn = document.createElement("button");
       btn.classList.add(btnLabel[1]);
       btn.textContent = btnLabel[0];
-      btns.push(btn);
-      subCell.appendChild(btn);
+      subOrNotBtns.push(btn);
+      displaySubCell.appendChild(btn);
     });
 
-    subCell.style.display = "none";
+    displaySubCell.style.display = "none";
 
-    this.gridElement.appendChild(subCell);
+    this.gridElement.appendChild(displaySubCell);
 
     return {
-      showDiv: journalCell,
-      hoverDiv: subCell,
-      subscribeBtn: btns[0],
-      unSubscribeBtn: btns[1],
+      showDiv: displayJournalCell,
+      hoverDiv: displaySubCell,
+      subscribeBtn: subOrNotBtns[0],
+      unSubscribeBtn: subOrNotBtns[1],
     };
   }
 
@@ -71,14 +71,14 @@ export class Journal {
     });
   }
 
-  renderGrid() {
+  renderToGridArticle() {
     const { showDiv, hoverDiv, subscribeBtn, unSubscribeBtn } =
-      this.getGridHTML();
+      this.getGridArticleHTML();
     this.addHoverEventToGrid(showDiv, hoverDiv);
     this.addSubEventToGrid(subscribeBtn, unSubscribeBtn, showDiv, hoverDiv);
   }
 
-  getdetailArticleHTML() {
+  getDetailArticleHTML() {
     const subNewsListHTML = this.journalData.subContent.subNewsList
       .map((item) => {
         return `<span>${item.trim()}</span>`;
@@ -121,8 +121,8 @@ export class Journal {
     });
   }
 
-  renderDetail() {
-    this.getdetailArticleHTML();
+  renderToDetailArticle() {
+    this.getDetailArticleHTML();
     this.addSubEventToDetail();
   }
 }

--- a/src/components/journalList/journal.js
+++ b/src/components/journalList/journal.js
@@ -90,7 +90,7 @@ export class Journal {
         <div class="detail-contents-column">
           <div class="imgSrc"><img style="height: 20px" src="${this.journalData.mediaInfo.imgSrc}"/></div>
           <div class="modifiedTime">${this.journalData.mediaInfo.modifiedTime}</div>
-          <div class="sub-button"><img src="src/assets/icons/SubscribeButton.svg" /></div>
+          <div class="sub-button"><button>+ 구독하기</button></div>
         </div>
         <div class="detail-contents-column">
           <div class="mainContent">

--- a/src/components/journalList/journal.js
+++ b/src/components/journalList/journal.js
@@ -114,7 +114,15 @@ export class Journal {
     this.detailElement.innerHTML += detailArticleHTML;
   }
 
+  addSubEventToDetail() {
+    const subscribeBtnjj = this.detailElement.querySelector(".sub-button");
+    subscribeBtnjj.addEventListener("click", () => {
+      this.journalHeaderStore.addSubscribe(this);
+    });
+  }
+
   renderDetail() {
     this.getdetailArticleHTML();
+    this.addSubEventToDetail();
   }
 }

--- a/src/components/journalList/journalHeader.js
+++ b/src/components/journalList/journalHeader.js
@@ -1,16 +1,15 @@
 export class JournalHeader {
-  constructor(store) {
-    this.journalHeaderStore = store;
+  constructor(journalHeaderStore) {
+    this.journalHeaderStore = journalHeaderStore;
     this.element = document.createElement("header");
     this.element.classList.add("journal-header", "display-flex");
-    this.render();
-    this.journalAllBtn;
-    this.journalSubBtn;
-    this.journalDetailBtn;
-    this.journalGridBtn;
+    this.renderJournalHeader();
   }
 
-  headerMarkup(currentState, currentFrame) {
+  getHeaderHTML() {
+    const currentState = this.journalHeaderStore.getState();
+    const currentFrame = this.journalHeaderStore.getFrame();
+
     const FONT_TITLE = "Title-MD";
     const FONT_BODY = "Body-MD";
     const SVG_DETAIL_OFF = "src/assets/icons/list-view.svg";
@@ -34,7 +33,7 @@ export class JournalHeader {
         ? SVG_GRID_ON
         : SVG_GRID_OFF;
 
-    const journalHeader = `
+    const journalHeaderHTML = `
       <div class="journal-area display-flex">
         <div class="journal-all ${fontAll}">전체 언론사</div>
         <div class="journal-subList ${fontSub}">내가 구독한 언론사</div>
@@ -49,39 +48,38 @@ export class JournalHeader {
       </div>
     `;
 
-    this.element.innerHTML = journalHeader;
+    this.element.innerHTML = journalHeaderHTML;
   }
 
-  addEvent() {
-    this.journalAllBtn.addEventListener("click", () => {
-      this.journalHeaderStore.setState("STATE_ALL");
-      this.render();
-    });
-
-    this.journalSubBtn.addEventListener("click", () => {
-      this.journalHeaderStore.setState("STATE_SUB");
-      this.render();
-    });
-
-    this.journalDetailBtn.addEventListener("click", () => {
-      this.journalHeaderStore.setFrame("FRAME_DETAIL");
-      this.render();
-    });
-
-    this.journalGridBtn.addEventListener("click", () => {
-      this.journalHeaderStore.setFrame("FRAME_GRID");
-      this.render();
-    });
-  }
-
-  render() {
-    const currentState = this.journalHeaderStore.getState();
-    const currentFrame = this.journalHeaderStore.getFrame();
-    this.headerMarkup(currentState, currentFrame);
+  addEventToHeader() {
     this.journalAllBtn = this.element.querySelector(".journal-all");
     this.journalSubBtn = this.element.querySelector(".journal-subList");
     this.journalDetailBtn = this.element.querySelector(".journal-btn__detail");
     this.journalGridBtn = this.element.querySelector(".journal-btn__grid");
-    this.addEvent();
+
+    this.journalAllBtn.addEventListener("click", () => {
+      this.journalHeaderStore.setState("STATE_ALL");
+      this.renderJournalHeader();
+    });
+
+    this.journalSubBtn.addEventListener("click", () => {
+      this.journalHeaderStore.setState("STATE_SUB");
+      this.renderJournalHeader();
+    });
+
+    this.journalDetailBtn.addEventListener("click", () => {
+      this.journalHeaderStore.setFrame("FRAME_DETAIL");
+      this.renderJournalHeader();
+    });
+
+    this.journalGridBtn.addEventListener("click", () => {
+      this.journalHeaderStore.setFrame("FRAME_GRID");
+      this.renderJournalHeader();
+    });
+  }
+
+  renderJournalHeader() {
+    this.getHeaderHTML();
+    this.addEventToHeader();
   }
 }

--- a/src/components/journalList/journalListView.js
+++ b/src/components/journalList/journalListView.js
@@ -95,14 +95,14 @@ const createJournalList = () => {
     const journalItems = await fetchJournalData(journalURL);
 
     const currentJournalType = journalDetailStore.getCurrentJournalType();
-    const chosenJounralList = journalItems.filter((journal) => {
+    const chosenJouralList = journalItems.filter((journal) => {
       if (journal.journalData.mediaInfo.type === currentJournalType) {
         return true;
       }
       return false;
     });
 
-    journalDetailStore.setDetailListAll(chosenJounralList);
+    journalDetailStore.setDetailListAll(chosenJouralList);
   };
 
   // batch 페이지에 언론사 디테일 삽입

--- a/src/components/journalList/journalListView.js
+++ b/src/components/journalList/journalListView.js
@@ -95,14 +95,11 @@ const createJournalList = () => {
     const journalItems = await fetchJournalData(journalURL);
 
     const currentJournalType = journalDetailStore.getCurrentJournalType();
-    const chosenJouralList = journalItems.filter((journal) => {
-      if (journal.journalData.mediaInfo.type === currentJournalType) {
-        return true;
-      }
-      return false;
-    });
+    const chosenJournalList = journalItems.filter(
+      (journal) => journal.journalData.mediaInfo.type === currentJournalType
+    );
 
-    journalDetailStore.setDetailListAll(chosenJouralList);
+    journalDetailStore.setDetailListAll(chosenJournalList);
   };
 
   // batch 페이지에 언론사 디테일 삽입

--- a/src/components/journalList/journalListView.js
+++ b/src/components/journalList/journalListView.js
@@ -21,7 +21,7 @@ const createJournalList = () => {
       return;
     }
 
-    journalTrack.render();
+    journalTrack.renderToJournalTrack();
 
     const journalContainer = document.querySelector(".journal-container");
     journalContainer.innerHTML = "";
@@ -51,7 +51,6 @@ const createJournalList = () => {
 
   const showSubscribePage = (journalList) => {
     batchJournalList(journalList);
-
     resetTrackButton();
   };
 
@@ -104,7 +103,7 @@ const createJournalList = () => {
 
   // batch 페이지에 언론사 디테일 삽입
   const renderJournalDetail = (currentState) => {
-    journalTrack.render();
+    journalTrack.renderToJournalTrack();
     const journalContainer = document.querySelector(".journal-container");
     journalContainer.innerHTML = "";
 
@@ -115,7 +114,7 @@ const createJournalList = () => {
     resetTrackButton();
   };
 
-  // 언론사 디테일 구속 리스트 전체 보여주기
+  // 언론사 리스트 디테일 페이지에 전체 보여주기
   const showJournalDetailAll = (journalContainer) => {
     journalTrack.getDetailNavHTML();
     journalTrack.addDetailNavEvent();
@@ -125,7 +124,7 @@ const createJournalList = () => {
     createJournalDetailItems(journalContainer, journalDetailAllItems);
   };
 
-  // 언론사 디테일 구독 리스트 보여주기
+  // 언론사 디테일 구독된 리스트만 보여주기
   const showJournalDetailSub = (journalContainer) => {
     const journalDetailSubItems = journalHeaderStore.journalSubscribe;
 
@@ -198,11 +197,12 @@ const createJournalList = () => {
     });
   };
 
+  // 트렉 렌더링 시 현재 페이지 기준의 버튼 리렌더링
   const resetTrackButton = () => {
     const batchElments = document.querySelectorAll(".journal-batch");
     journalTrackStore.setBatchSize(batchElments);
-    journalTrack.addButton();
-    journalTrack.addEvent();
+    journalTrack.addTrackMoveButtons();
+    journalTrack.addMoveEventToBtns();
   };
 
   loadJournalItems().catch((error) => console.error(error));

--- a/src/components/journalList/journalTrack.js
+++ b/src/components/journalList/journalTrack.js
@@ -1,21 +1,20 @@
 export class Track {
   constructor(journalTrackStore, journalDetailStore) {
-    this.store = journalTrackStore;
-    this.detailStore = journalDetailStore;
+    this.journalTrackStore = journalTrackStore;
+    this.journalDetailStore = journalDetailStore;
     this.element = document.createElement("div");
     this.element.classList.add("journal-track");
-    this.prevBtn;
-    this.nextBtn;
+    this.currentBatchSize = this.journalTrackStore.getBatchSize();
     this.currentPage = 0;
-    this.render();
+    this.renderToJournalTrack();
   }
 
-  beElement() {
+  getTrackContainerHTML() {
     const journalTrack = `<div class="journal-container"></div>`;
     this.element.innerHTML = journalTrack;
   }
 
-  addButton() {
+  addTrackMoveButtons() {
     const leftBtn = document.createElement("button");
     leftBtn.classList.add("track-btn_left");
     const leftImg = document.createElement("img");
@@ -33,22 +32,22 @@ export class Track {
   }
 
   moveTrack(direction) {
-    this.container = this.element.querySelector(".journal-container");
-    this.batchSize = this.store.getBatchSize();
+    const trackContainer = this.element.querySelector(".journal-container");
+
     const WIDTH_PER_PAGE = 900;
     const FIRST_PAGE = 0;
-    const LAST_PAGE = this.store.getBatchSize() - 1;
+    const LAST_PAGE = this.currentBatchSize - 1;
 
     if (direction === "left") {
       this.currentPage--;
-      this.countCurrentPage();
+      this.updateDetailNav();
     } else if (direction === "right") {
       this.currentPage++;
-      this.countCurrentPage();
+      this.updateDetailNav();
     }
 
     const currentPosition = this.currentPage * -WIDTH_PER_PAGE;
-    this.container.style.transform = `translateX(${currentPosition}px)`;
+    trackContainer.style.transform = `translateX(${currentPosition}px)`;
 
     if (LAST_PAGE === FIRST_PAGE) {
       this.prevBtn.classList.add("display-none");
@@ -63,12 +62,12 @@ export class Track {
     }
   }
 
-  addEvent() {
-    this.batchSize = this.store.getBatchSize();
+  addMoveEventToBtns() {
+    this.currentBatchSize = this.journalTrackStore.getBatchSize();
     this.prevBtn = this.element.querySelector(".track-btn_left");
     this.nextBtn = this.element.querySelector(".track-btn_right");
 
-    if (this.batchSize === 1) {
+    if (this.currentBatchSize === 1) {
       this.prevBtn.classList.add("display-none");
       this.nextBtn.classList.add("display-none");
     }
@@ -79,6 +78,7 @@ export class Track {
     this.nextBtn.addEventListener("click", () => this.moveTrack("right"));
   }
 
+  // 언론사 디테일 렌더링시 navBar 추가
   getDetailNavHTML() {
     const detailNavDiv = document.createElement("nav");
     detailNavDiv.classList.add("detail-type-bar");
@@ -110,18 +110,18 @@ export class Track {
     const journalContainer = document.querySelector(".journal-container");
 
     this.element.insertBefore(detailNavDiv, journalContainer);
-    this.countCurrentPage();
+    this.updateDetailNav();
   }
 
-  countCurrentPage() {
+  updateDetailNav() {
     const typeList = [
       ...document.querySelectorAll(".navType span:first-child"),
     ];
 
     typeList.forEach((type) => {
-      if (type.innerText === this.detailStore.currentJournalType) {
+      if (type.innerText === this.journalDetailStore.currentJournalType) {
         const typePage = `<span class="type-page">${this.currentPage + 1} / ${
-          this.detailStore.getDetailListAll().length
+          this.journalDetailStore.getDetailListAll().length
         }</span>`;
 
         const typePageElement = type.parentNode.querySelector(".type-page");
@@ -145,12 +145,12 @@ export class Track {
 
       const chosenJournalType = eventTarget.innerText;
 
-      this.detailStore.setCurrentJournalType(chosenJournalType);
+      this.journalDetailStore.setCurrentJournalType(chosenJournalType);
     });
   }
 
-  render() {
+  renderToJournalTrack() {
     this.currentPage = 0;
-    this.beElement();
+    this.getTrackContainerHTML();
   }
 }

--- a/src/store/journalTrackStore.js
+++ b/src/store/journalTrackStore.js
@@ -1,13 +1,13 @@
 export class JournalTrackStore {
   constructor() {
-    this.pageSize;
+    this.batchPageSize;
   }
 
   setBatchSize(batchElments) {
-    this.pageSize = batchElments.length;
+    this.batchPageSize = batchElments.length;
   }
 
   getBatchSize() {
-    return this.pageSize;
+    return this.batchPageSize;
   }
 }


### PR DESCRIPTION
<details>
<summary>Feature List</summary>
 </br>

1. JournalHeader 영역
- [x] : JournalHeader에 "전체 언론사" "구독중인 언론사" 클릭시의 이벤트를 부여한다.
- [x] : "전체 언론사" 클릭시 JournalHeaderStore은 "ALL"의 상태를 가진다.
- [x] : "구족중인 언론사" 클릭시 "SUB"의 상태를 가진다.
- [x] : 이벤트 발생과 동시에 JournalHeader의 클릭된 "항목"의 글씨가 굵어지는 렌더링이 일어난다.

2. Journal 그리드 영역
- [x] : JournalHeaderStore에 JournalListAll = [], JournalSubList = []의 상태를 가진다.
- [x] : JournalHeaderStore의 상태("ALL", "SUB")에 따라 해당하는 리스트를 렌더링 해준다.
- [x] : 각 언론사에 마우스를 올리면 [구독하기] 버튼 보이도록 한다.
- [ ] : 이미 구독하고 있는 언론사의 경우 [해지하기] 버튼이 보이도록 한다.
- [x] : Journal의 "구독" 버튼을 누르면 JournalSubList배열에 추가된다.
- [x] : Jounnal의 "해지" 버튼을 누르면 JournalSubList배열에서 해당 언론사가 제거된다.
- [x] : [내가 구독한 언론사] 클릭시 구독을 누른 언론사만 보이게 한다.
- [ ] : 구족중인 언론사위에 마우스를 올리면 [구독해지] 버튼이 나온다
- [x] : 구독해지시 즉시 렌더링 되도록 한다.

3. Journal 디테일(전체) 영역
- [x] : 244개의 언론사를 카테고리로 분류한다. (상단에 카테고리 영역 구성)
- [x] : 선택된 카테고리 이름 옆에 해당 카테고리에 속해있는 언론사의 갯수와 순서를 표시한다.
- [x] : 언론사의 순서는 랜덤으로 정해진다.
- [x] : 아래 화면에는 현재의 언론사 내용을 표시한다.
- [x] : 좌우 화살표로 다음, 이전 언론사로 넘어가도록 한다.
- [x] : 각 카테고리 클릭시 해당 언론사 리스트로 이동한다.
- [x] : 언론사 내용에는 구독하기 버튼을 추가한다.
- [ ] : 구독하기 클릭 시 "내가 구독한 언론사에 추가되었습니다."라는 스낵바가 나오게 한다.
- [x] : 내가 구독한 언론사에 추가되도록 한다.
- [ ] : 내가 구독한 언론사에서는 해지하기 버튼이 보이도록 한다.
- [ ] : 해지하기 클릭 시 내가 구독한 리스트에서 제거한다.
</details>


<details>
<summary>뉴스 스탠드 설계도 (현상황)</summary>
 </br>
<img width="912" alt="image" src="https://user-images.githubusercontent.com/109648042/234071829-aed46f60-e9e3-44eb-b8b3-6ba64dfb876e.png">
</details>

처음 목표를 잡았던 기능까지는 구현을 완성했다.
4주차는 테스트 코드 학습과 구현 및 리펙토링을 진행하고자 한다.
